### PR TITLE
jwt 토큰 적용

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Logger, Post, Body, Get, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignInDto } from './dto/signIn.dto';
+import { Public } from './decorators/public.decorator';
 
 @Controller('auth')
 @ApiTags('Auth API')
@@ -9,6 +10,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
   private readonly logger = new Logger(AuthController.name);
 
+  @Public()
   @ApiOperation({ summary: '로그인' })
   @Post()
   async signIn(@Body() signInDto: SignInDto) {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -22,10 +22,10 @@ import { AuthGuard } from './auth.guard';
   controllers: [AuthController],
   providers: [
     AuthService,
-    // { //가드를 전역으로
-    //   provide: APP_GUARD,
-    //   useClass: AuthGuard,
-    // },
+    {
+      provide: APP_GUARD,
+      useClass: AuthGuard,
+    },
   ],
   exports: [AuthService],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -25,7 +25,7 @@ export class AuthService {
         return { success: false, msg: '비밀번호가 일치하지 않습니다.' };
 
       const payload = {
-        sub: user.userId,
+        userId: user.id,
         username: user.name,
         nickname: user.nickname,
         imgUrl: user.img,

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Param,
   UseGuards,
+  Headers,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { BoardService } from './board.service';
@@ -44,16 +45,16 @@ export class BoardController {
 
   @ApiOperation({ summary: '게시판 작성' })
   @Post('/create')
-  async create(@Body() createData: CreateBoardDto) {
+  async create(@Body() createData: CreateBoardDto, @Headers() headers) {
     this.logger.log('-----POST /board/create');
-    return await this.boardService.create(createData);
+    return await this.boardService.create(createData, headers);
   }
 
   @ApiOperation({ summary: '게시글 삭제' })
   @Delete('/delete')
-  async delete(@Body() deleteData: DeleteBoardDto) {
+  async delete(@Body() deleteData: DeleteBoardDto, @Headers() headers) {
     this.logger.log('-----DELETE /board/delete');
-    return await this.boardService.delete(deleteData);
+    return await this.boardService.delete(deleteData, headers);
   }
 
   @ApiOperation({ summary: '게시글 수정 전 가져오기' })
@@ -65,9 +66,9 @@ export class BoardController {
 
   @ApiOperation({ summary: '게시글 수정' })
   @Patch('/update')
-  async update(@Body() updateData: UpdateBoardDto) {
+  async update(@Body() updateData: UpdateBoardDto, @Headers() headers) {
     this.logger.log('-----PATCH /board/update');
-    return await this.boardService.update(updateData);
+    return await this.boardService.update(updateData, headers);
   }
 
   @ApiOperation({ summary: '게시글 열람' })
@@ -86,9 +87,12 @@ export class BoardController {
 
   @ApiOperation({ summary: '게시글 추천' })
   @Post('/recommend')
-  async recommend(@Body() recommendData: RecommendBoardDto) {
+  async recommend(
+    @Body() recommendData: RecommendBoardDto,
+    @Headers() headers,
+  ) {
     this.logger.log('-----POST /board/recommend');
-    return await this.boardService.recommend(recommendData);
+    return await this.boardService.recommend(recommendData, headers);
   }
 
   @ApiOperation({ summary: '댓글 열람' })
@@ -100,23 +104,41 @@ export class BoardController {
 
   @ApiOperation({ summary: '댓글 작성' })
   @Post('/comment/create')
-  async createComment(@Body() createCommentData: CreateCommentDto) {
+  async createComment(
+    @Body() createCommentData: CreateCommentDto,
+    @Headers() headers,
+  ) {
     this.logger.log('-----POST /comment/create');
-    return await this.boardCommentService.createComment(createCommentData);
+    return await this.boardCommentService.createComment(
+      createCommentData,
+      headers,
+    );
   }
 
   @ApiOperation({ summary: '댓글 수정' })
   @Patch('/comment/update')
-  async updateComment(@Body() updateCommentData: UpdateCommentDto) {
+  async updateComment(
+    @Body() updateCommentData: UpdateCommentDto,
+    @Headers() headers,
+  ) {
     this.logger.log('-----POST /comment/update');
-    return await this.boardCommentService.updateComment(updateCommentData);
+    return await this.boardCommentService.updateComment(
+      updateCommentData,
+      headers,
+    );
   }
 
   @ApiOperation({ summary: '댓글 삭제' })
   @Delete('/comment/delete')
-  async deleteComment(@Body() deleteCommentData: DeleteCommentDto) {
+  async deleteComment(
+    @Body() deleteCommentData: DeleteCommentDto,
+    @Headers() headers,
+  ) {
     this.logger.log('-----Delete /comment/delete');
-    return await this.boardCommentService.deleteComment(deleteCommentData);
+    return await this.boardCommentService.deleteComment(
+      deleteCommentData,
+      headers,
+    );
   }
 
   @ApiOperation({ summary: '신고 리스트 불러오기' })
@@ -140,9 +162,9 @@ export class BoardController {
     return await this.boardService.banBoard(banBoardDto);
   }
 
-  @ApiOperation({ summary: '카테고리 조회'})
+  @ApiOperation({ summary: '카테고리 조회' })
   @Get('/category')
-  async getCategoryList(){
+  async getCategoryList() {
     this.logger.log('-----GET /category');
     return await this.boardService.getCategoryList();
   }

--- a/src/board/dto/create-board.dto.ts
+++ b/src/board/dto/create-board.dto.ts
@@ -8,9 +8,6 @@ export class CreateBoardDto {
   readonly contents: string;
 
   @IsNumber()
-  readonly userId: number;
-
-  @IsNumber()
   readonly boardCategoryId: number;
 
   @IsOptional()

--- a/src/board/dto/create-comment.dto.ts
+++ b/src/board/dto/create-comment.dto.ts
@@ -5,8 +5,5 @@ export class CreateCommentDto {
   readonly contents: string;
 
   @IsNumber()
-  readonly userId: number;
-
-  @IsNumber()
   readonly boardId: number;
 }

--- a/src/board/dto/recommend-board.dto.ts
+++ b/src/board/dto/recommend-board.dto.ts
@@ -2,8 +2,5 @@ import { IsNumber } from 'class-validator';
 
 export class RecommendBoardDto {
   @IsNumber()
-  readonly userId: number;
-
-  @IsNumber()
   readonly boardId: number;
 }

--- a/src/board/dto/update-board.dto.ts
+++ b/src/board/dto/update-board.dto.ts
@@ -4,4 +4,7 @@ import { CreateBoardDto } from './create-board.dto';
 export class UpdateBoardDto extends CreateBoardDto {
   @IsNumber()
   id: number;
+
+  @IsNumber()
+  userId: number;
 }

--- a/src/board/dto/update-comment.dto.ts
+++ b/src/board/dto/update-comment.dto.ts
@@ -4,4 +4,7 @@ import { CreateCommentDto } from './create-comment.dto';
 export class UpdateCommentDto extends CreateCommentDto {
   @IsNumber()
   id: number;
+
+  @IsNumber()
+  userId: number;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -3,7 +3,9 @@ import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CheckCodeDto } from './dto/check-email.dto';
+import { Public } from 'src/auth/decorators/public.decorator';
 
+@Public()
 @Controller('user')
 @ApiTags('User API')
 export class UserController {


### PR DESCRIPTION
# 작업
1. 기존 payload에서 sub: 유저아이디 -> userId: 유저아이디 로 변경

2. auth.module.ts에서 가드를 전역으로 등록

3. 로그인 api는 토큰 없이도 접근 가능하게 Public() 데코레이터 적용

4. 게시판 관련 기능에서 header를 받고 확인
- dto에서 필요에 의해 추가, 삭제
- 컨트롤러에서 헤더 받기
- 서비스에서 헤더 사용

5. jwt 토큰 기한 만료는 임의로 하루로 했습니다.
만료시 가드에서 401 Unauthorized를 뿌립니다.